### PR TITLE
Fix timestamp URL, the old one doesn't exist anymore

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ function spawnSign (options, callback) {
     '-out',
     outputPath,
     '-t',
-    'http://timestamp.verisign.com/scripts/timstamp.dll'
+    'http://timestamp.globalsign.com/scripts/timstamp.dll'
   ]
 
   var certExtension = path.extname(options.cert)


### PR DESCRIPTION
It was causing the signing to fail:
```
Signing failed with 255. CURL failure: Failure when receiving data from the peer authenti
code timestamping failed
```